### PR TITLE
52-patch

### DIFF
--- a/src/main/java/app/persistence/mappers/testSetupForMappers/CreateTestSchemaDatabase.java
+++ b/src/main/java/app/persistence/mappers/testSetupForMappers/CreateTestSchemaDatabase.java
@@ -186,7 +186,7 @@ public class CreateTestSchemaDatabase {
         INSERT INTO test.orders (offer_id, status_id, purchase_date)
         VALUES
             (1, 1, '2025-05-01'),
-            (2, 2, '2025-05-02'),
+            (2, 2, '2025-05-02');
 
         INSERT INTO test.orders (offer_id, status_id, purchase_date, tracking_number)
         VALUES

--- a/src/test/java/app/persistence/mappers/OrderMapperTest.java
+++ b/src/test/java/app/persistence/mappers/OrderMapperTest.java
@@ -98,6 +98,7 @@ class OrderMapperTest {
 
         // Act: Get status via tracking_number
         Status status = orderMapper.getStatusFromTrackingNumber(connectionPool, trackingNumber);
+
         // Assert:
         assertNotNull(status);
         assertEquals(1, status.getStatusId());


### PR DESCRIPTION
Fiksede integrationstest fejl. De kører alle grønt nu. Der var en , i stedte for ;