### PR TITLE
Scram authentication fejl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      kudsk_db_password: ${{ secrets.KUDSK_DB_PASSWORD }}
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Scram authentication no auth fixed med brug af repository secrets. Jeg har tilføjet en linje kode, som gør at vores auto-integrations & Unit test kan læse hvad vores database password er. Dette er gemt langt ned i selve repository secrets.