### PR TITLE
78-quickpatch

### DIFF
--- a/src/main/java/app/persistence/controller/RoutingController.java
+++ b/src/main/java/app/persistence/controller/RoutingController.java
@@ -116,7 +116,6 @@ public class RoutingController {
         ctx.redirect("/final-accept-offer");
     }
 
-
     public static void showAcceptOfferPage(Context ctx) {
         ctx.render("/accept-offer.html");
     }

--- a/src/main/java/app/persistence/controller/RoutingController.java
+++ b/src/main/java/app/persistence/controller/RoutingController.java
@@ -162,49 +162,56 @@ public class RoutingController {
     }
 
     private static void handleQuickBygPage(Context ctx) {
-        if (ctx.formParam("carportWidth") != null) {
-            int carportWidth = Integer.parseInt(ctx.formParam("carportWidth"));
-            int carportLength = Integer.parseInt(ctx.formParam("carportLength"));
-            String carportTrapezRoof = ctx.formParam("carportTrapezroof");
-            boolean redskabsrumCheckbox = ctx.formParam("redskabsrumCheckbox") != null;
-            int redskabsrumLength = Integer.parseInt(ctx.formParam("redskabsrumLength"));
-            int redskabsrumWidth = Integer.parseInt(ctx.formParam("redskabsrumWidth"));
-            int redskabsrumDoors = Integer.parseInt(ctx.formParam("redskabsrumDoors"));
+        String widthStr = ctx.formParam("carportWidth");
+        String lengthStr = ctx.formParam("carportLength");
+        String roofStr = ctx.formParam("carportTrapezroof");
+        String shedCheckbox = ctx.formParam("redskabsrumCheckbox");
+        String shedLenStr = ctx.formParam("redskabsrumLength");
+        String shedWidStr = ctx.formParam("redskabsrumWidth");
+        String shedDoorsStr = ctx.formParam("redskabsrumDoors");
 
-            ctx.sessionAttribute("carportWidth", carportWidth);
-            ctx.sessionAttribute("carportLength", carportLength);
-            ctx.sessionAttribute("carportTrapezRoof", carportTrapezRoof);
-            ctx.sessionAttribute("redskabsrumCheckbox", redskabsrumCheckbox);
-            ctx.sessionAttribute("redskabsrumLength", redskabsrumLength);
-            ctx.sessionAttribute("redskabsrumWidth", redskabsrumWidth);
-            ctx.sessionAttribute("redskabsrumDoors", redskabsrumDoors);
+        int carportWidth = 0;
+        int carportLength = 0;
+        String carportTrapezRoof = "";
+        boolean hasShed = false;
+        int shedLen = 0;
+        int shedWid = 0;
+        int shedDoors = 0;
+
+        if (widthStr != null && !widthStr.isEmpty()) {
+            carportWidth = Integer.parseInt(widthStr);
         }
+        if (lengthStr != null && !lengthStr.isEmpty()) {
+            carportLength = Integer.parseInt(lengthStr);
+        }
+        if (roofStr != null) {
+            carportTrapezRoof = roofStr;
+        }
+        if (shedCheckbox != null) {
+            hasShed = true;
+            if (shedLenStr != null && !shedLenStr.isEmpty()) {
+                shedLen = Integer.parseInt(shedLenStr);
+            }
+            if (shedWidStr != null && !shedWidStr.isEmpty()) {
+                shedWid = Integer.parseInt(shedWidStr);
+            }
+            if (shedDoorsStr != null && !shedDoorsStr.isEmpty()) {
+                shedDoors = Integer.parseInt(shedDoorsStr);
+            }
+        }
+        ctx.sessionAttribute("carportWidth", carportWidth);
+        ctx.sessionAttribute("carportLength", carportLength);
+        ctx.sessionAttribute("carportTrapezRoof", carportTrapezRoof);
+        ctx.sessionAttribute("redskabsrumCheckbox", hasShed);
+        ctx.sessionAttribute("redskabsrumLength", shedLen);
+        ctx.sessionAttribute("redskabsrumWidth", shedWid);
+        ctx.sessionAttribute("redskabsrumDoors", shedDoors);
+
         ctx.render("/quick-byg-contact-information.html");
     }
 
     private static void showQuickBygPage(Context ctx) {
-        if (ctx.sessionAttribute("carportWidth") != null) {
-            ctx.attribute("carportWidth", ctx.sessionAttribute("carportWidth"));
-        }
-        if (ctx.sessionAttribute("carportLength") != null) {
-            ctx.attribute("carportLength", ctx.sessionAttribute("carportLength"));
-        }
-        if (ctx.sessionAttribute("carportTrapezRoof") != null) {
-            ctx.attribute("carportTrapezRoof", ctx.sessionAttribute("carportTrapezRoof"));
-        }
-        if (ctx.sessionAttribute("redskabsrumCheckbox") != null) {
-            ctx.attribute("redskabsrumCheckbox", ctx.sessionAttribute("redskabsrumCheckbox"));
-        }
-        if (ctx.sessionAttribute("redskabsrumLength") != null) {
-            ctx.attribute("redskabsrumLength", ctx.sessionAttribute("redskabsrumLength"));
-        }
-        if (ctx.sessionAttribute("redskabsrumWidth") != null) {
-            ctx.attribute("redskabsrumWidth", ctx.sessionAttribute("redskabsrumWidth"));
-        }
-        if (ctx.sessionAttribute("redskabsrumDoors") !=null) {
-            ctx.attribute("redskabsrumDoors", ctx.sessionAttribute("redskabsrumDoors"));
-        }
-
+        carportAttributes(ctx);
         ctx.render("/quick-byg.html");
     }
 
@@ -247,14 +254,7 @@ public class RoutingController {
     }
 
     public static void showConfirmationPage(Context ctx) {
-        ctx.attribute("carportWidth", ctx.sessionAttribute("carportWidth"));
-        ctx.attribute("carportLength", ctx.sessionAttribute("carportLength"));
-        ctx.attribute("carportTrapezRoof", ctx.sessionAttribute("carportTrapezRoof"));
-        ctx.attribute("redskabsrumCheckbox", ctx.sessionAttribute("redskabsrumCheckbox"));
-        ctx.attribute("redskabsrumLength", ctx.sessionAttribute("redskabsrumLength"));
-        ctx.attribute("redskabsrumWidth", ctx.sessionAttribute("redskabsrumWidth"));
-        ctx.attribute("redskabsrumDoors", ctx.sessionAttribute("redskabsrumDoors"));
-
+        carportAttributes(ctx);
         ctx.render("/quick-byg-confirmation.html");
     }
 
@@ -263,11 +263,21 @@ public class RoutingController {
 
     public static void showMailSentPage(Context ctx) {
         ctx.render("/quick-byg-mail-sent.html");
-        try  {
+        try {
             mailSender.sendFirstMail(getCustomerEmail(ctx), getCustomerFirstName(ctx), getCustomerEmail(ctx));
         } catch (IOException e) {
             System.out.println(e.getMessage());
         }
+    }
+
+    public static void carportAttributes(Context ctx) {
+        ctx.attribute("carportWidth", ctx.sessionAttribute("carportWidth"));
+        ctx.attribute("carportLength", ctx.sessionAttribute("carportLength"));
+        ctx.attribute("carportTrapezRoof", ctx.sessionAttribute("carportTrapezRoof"));
+        ctx.attribute("redskabsrumCheckbox", ctx.sessionAttribute("redskabsrumCheckbox"));
+        ctx.attribute("redskabsrumLength", ctx.sessionAttribute("redskabsrumLength"));
+        ctx.attribute("redskabsrumWidth", ctx.sessionAttribute("redskabsrumWidth"));
+        ctx.attribute("redskabsrumDoors", ctx.sessionAttribute("redskabsrumDoors"));
     }
 
     public static String getCustomerFirstName(Context ctx) {

--- a/src/main/java/app/persistence/mappers/OfferMapper.java
+++ b/src/main/java/app/persistence/mappers/OfferMapper.java
@@ -83,4 +83,9 @@ public class OfferMapper {
     public static String getCustomerMailFromOfferId(ConnectionPool connection, int offerId){
         return "test@kunde.dk";
     }
+
+    public static String getSellerMailFromOfferId(ConnectionPool connectionPool, int offerId){
+        return "sellersatjohannesfog@gmail.com";
+    }
+
 }

--- a/src/main/java/app/persistence/util/MailSender.java
+++ b/src/main/java/app/persistence/util/MailSender.java
@@ -27,8 +27,9 @@ public class MailSender {
         //Her skal vi hente sessionattributes ind, så vi kan bruge dem som en værdi
         personalization.addTo(new Email(to));
         personalization.addDynamicTemplateData("name", name);
-        personalization.addDynamicTemplateData("email", email);
-
+       // personalization.addDynamicTemplateData("price", price);
+      //  personalization.addDynamicTemplateData("offerId", offerId);
+        //personalization.addDynamicTemplateData("offerIdLink", offerIdLink);
         mail.addPersonalization(personalization);
         mail.addCategory("carportapp");
 

--- a/src/main/resources/templates/quick-byg-confirmation.html
+++ b/src/main/resources/templates/quick-byg-confirmation.html
@@ -99,12 +99,17 @@
 
         <ul class="confirmation-list">
             <b>Her er dine valgte mål til din carport:</b>
-            <li></li>
             <li>Længde: <span th:text="${carportLength + ' cm'}">[mangler længde]</span></li>
             <li>Bredde: <span th:text="${carportWidth + ' cm'}">[mangler bredde]</span></li>
             <li>Tagtype: <span th:text="${carportTrapezRoof}">[mangler tagtype]</span></li>
-            <li th:if="${redskabsrumCheckbox}">
+
+            <li>
                 Redskabsrum:
+                <span th:if="${redskabsrumCheckbox}">Ja</span>
+                <span th:unless="${redskabsrumCheckbox}">Nej</span>
+            </li>
+
+            <li th:if="${redskabsrumCheckbox}">
                 <ul>
                     <li>Længde: <span th:text="${redskabsrumLength + ' cm'}">[mangler længde]</span></li>
                     <li>Bredde: <span th:text="${redskabsrumWidth + ' cm'}">[mangler bredde]</span></li>

--- a/src/main/resources/templates/quick-byg.html
+++ b/src/main/resources/templates/quick-byg.html
@@ -98,7 +98,7 @@
         <div class="carport-dropdown-menus">
             <form method="post" th:action="@{/quickByg}">
                 <p>Carport bredde</p>
-                <select name="carportWidth">
+                <select name="carportWidth" required>
                     <option value="">Vælg Bredde</option>
                     <th:block th:each="width : ${#numbers.sequence(240, 600, 30)}">
                         <option th:value="${width}"
@@ -108,7 +108,7 @@
                 </select>
 
                 <p>Carport længde</p>
-                <select name="carportLength">
+                <select name="carportLength" required>
                     <option value="">Vælg Længde</option>
                     <th:block th:each="length : ${#numbers.sequence(240, 780, 30)}">
                         <option th:value="${length}"
@@ -120,7 +120,7 @@
                 </select>
 
                 <p>Carport trapeztag</p>
-                <select name="carportTrapezroof">
+                <select name="carportTrapezroof" required>
                     <option value="">Vælg Tagplader</option>
                     <option value="Plastmo Ecolite blåtonet"
                             th:selected="${carportTrapezRoof == 'Plastmo Ecolite blåtonet'}">Plastmo Ecolite blåtonet</option>


### PR DESCRIPTION
I dette quickpatch er det rettet

* Logik med hvad "Redskabsrum" skal vise (Ja / Nej)
Lige nu så viser den Redskabsrum: Nej, selv hvis du ikke klikker på boksen. Før kom der slet ikke noget frem på confirmation siden. Klikker du så Ja til et redskabsrum, vil der står Redskabsrum: ja til sidst

* Kommet "required" attribut på carport bredde, længde og trapez tag.
Nu skal du indtaste en værdi, for at gå videre.

* Default værdi er 0 på redskabsrum, hvis man ikke vælger noget.
Dens attribut bliver sat til at være 0, hvis man overhovedet ikke vælger en værdi til det. Før fejlede det fordi vi satte det til at være null, men man kan ikke Integer.parse en null værdi, hvilket gjorde der kom server error

* Fjernet duplicate kode og smidt det i en metode
Der var mange gentagelse af alle carport session/ attributterne så har valgt at smide dem i en metode
public static void carportAttributes(Context ctx) som vi kører i stedet for, når vi skal load

